### PR TITLE
🧹 Deduplicate VTK Cell Type Constants (Final)

### DIFF
--- a/examples/vtkhdf_demo.F90
+++ b/examples/vtkhdf_demo.F90
@@ -2,6 +2,7 @@ program vtkhdf_demo
 
   use,intrinsic :: iso_fortran_env, only: r8 => real64, int8
   use vtkhdf_mb_file_type
+  use vtkhdf_vtk_cell_types
   use mpi
   implicit none
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ add_fypp_sources(GEN_SRC SOURCES ${FYPP_SRC} FLAGS --line-numbering)
 
 set(SRC
   vtkhdf_assert.F90
+  vtkhdf_vtk_cell_types.F90
   vtkhdf_h5_c_binding.F90
   vtkhdf_version_param.F90
   vtkhdf_h5e_context_type.F90

--- a/src/vtkhdf_mb_file_type.F90.fypp
+++ b/src/vtkhdf_mb_file_type.F90.fypp
@@ -86,12 +86,6 @@ module vtkhdf_mb_file_type
     final :: pdc_block_delete
   end type
 
-  !! TODO: get a more exhaustive list, separate module
-  integer(int8), parameter, public :: VTK_TETRA = 10
-  integer(int8), parameter, public :: VTK_HEXAHEDRON = 12
-  integer(int8), parameter, public :: VTK_WEDGE = 13
-  integer(int8), parameter, public :: VTK_PYRAMID = 14
-
 contains
 
   !! Finalizer for vtkhdf_mb_file objects. We free heap memory we own but avoid

--- a/src/vtkhdf_ug_file_type.F90.fypp
+++ b/src/vtkhdf_ug_file_type.F90.fypp
@@ -71,12 +71,6 @@ module vtkhdf_ug_file_type
     final :: vtkhdf_ug_file_delete
   end type
 
-  !! TODO: get a more exhaustive list, separate module
-  integer(int8), parameter, public :: VTK_TETRA = 10
-  integer(int8), parameter, public :: VTK_HEXAHEDRON = 12
-  integer(int8), parameter, public :: VTK_WEDGE = 13
-  integer(int8), parameter, public :: VTK_PYRAMID = 14
-
 contains
 
   !! Finalizer for VTKHDF_UG_FILE objects. We free heap memory we own but avoid

--- a/src/vtkhdf_vtk_cell_types.F90
+++ b/src/vtkhdf_vtk_cell_types.F90
@@ -1,0 +1,46 @@
+module vtkhdf_vtk_cell_types
+  use, intrinsic :: iso_fortran_env, only: int8
+  implicit none
+  public
+
+  !! Standard VTK Cell Types
+  !! See https://docs.vtk.org/en/latest/vtk_file_formats/vtkhdf_file_format/index.html#
+  !! and Common/DataModel/vtkCellType.h in the VTK source code.
+
+  integer(int8), parameter :: VTK_EMPTY_CELL = 0
+  integer(int8), parameter :: VTK_VERTEX = 1
+  integer(int8), parameter :: VTK_POLY_VERTEX = 2
+  integer(int8), parameter :: VTK_LINE = 3
+  integer(int8), parameter :: VTK_POLY_LINE = 4
+  integer(int8), parameter :: VTK_TRIANGLE = 5
+  integer(int8), parameter :: VTK_TRIANGLE_STRIP = 6
+  integer(int8), parameter :: VTK_POLYGON = 7
+  integer(int8), parameter :: VTK_PIXEL = 8
+  integer(int8), parameter :: VTK_QUAD = 9
+  integer(int8), parameter :: VTK_TETRA = 10
+  integer(int8), parameter :: VTK_VOXEL = 11
+  integer(int8), parameter :: VTK_HEXAHEDRON = 12
+  integer(int8), parameter :: VTK_WEDGE = 13
+  integer(int8), parameter :: VTK_PYRAMID = 14
+  integer(int8), parameter :: VTK_PENTAGONAL_PRISM = 15
+  integer(int8), parameter :: VTK_HEXAGONAL_PRISM = 16
+
+  !! Quadratic, isoparametric cells
+  integer(int8), parameter :: VTK_QUADRATIC_EDGE = 21
+  integer(int8), parameter :: VTK_QUADRATIC_TRIANGLE = 22
+  integer(int8), parameter :: VTK_QUADRATIC_QUAD = 23
+  integer(int8), parameter :: VTK_QUADRATIC_TETRA = 24
+  integer(int8), parameter :: VTK_QUADRATIC_HEXAHEDRON = 25
+  integer(int8), parameter :: VTK_QUADRATIC_WEDGE = 26
+  integer(int8), parameter :: VTK_QUADRATIC_PYRAMID = 27
+  integer(int8), parameter :: VTK_BIQUADRATIC_QUAD = 28
+  integer(int8), parameter :: VTK_TRIQUADRATIC_HEXAHEDRON = 29
+  integer(int8), parameter :: VTK_QUADRATIC_LINEAR_QUAD = 30
+  integer(int8), parameter :: VTK_QUADRATIC_LINEAR_WEDGE = 31
+  integer(int8), parameter :: VTK_BIQUADRATIC_QUADRATIC_WEDGE = 32
+  integer(int8), parameter :: VTK_BIQUADRATIC_QUADRATIC_HEXAHEDRON = 33
+  integer(int8), parameter :: VTK_BIQUADRATIC_TRI_QUADRATIC_HEXAHEDRON = 34
+  integer(int8), parameter :: VTK_QUADRATIC_POLYGON = 36
+  integer(int8), parameter :: VTK_TRIQUADRATIC_PYRAMID = 37
+
+end module vtkhdf_vtk_cell_types

--- a/test/vtkhdf_mb_test-serial.F90
+++ b/test/vtkhdf_mb_test-serial.F90
@@ -2,6 +2,7 @@ program vtkhdf_mb_test
 
   use,intrinsic :: iso_fortran_env, only: r8 => real64, int8
   use vtkhdf_mb_file_type
+  use vtkhdf_vtk_cell_types
   implicit none
 
   real(r8), allocatable :: x(:,:), scalar_cell_data(:), vector_cell_data(:,:)

--- a/test/vtkhdf_mb_test.F90
+++ b/test/vtkhdf_mb_test.F90
@@ -2,6 +2,7 @@ program vtkhdf_mb_test
 
   use,intrinsic :: iso_fortran_env, only: r8 => real64, int8
   use vtkhdf_mb_file_type
+  use vtkhdf_vtk_cell_types
   use mpi
   implicit none
 

--- a/test/vtkhdf_ug_test-serial.F90
+++ b/test/vtkhdf_ug_test-serial.F90
@@ -2,6 +2,7 @@ program vtkhdf_ug_test
 
   use,intrinsic :: iso_fortran_env, only: r8 => real64, int8
   use vtkhdf_ug_file_type
+  use vtkhdf_vtk_cell_types
   implicit none
 
   real(r8), allocatable :: x(:,:), scalar_cell_data(:), vector_cell_data(:,:)

--- a/test/vtkhdf_ug_test.F90
+++ b/test/vtkhdf_ug_test.F90
@@ -2,6 +2,7 @@ program vtkhdf_ug_test
 
   use,intrinsic :: iso_fortran_env, only: r8 => real64, int8
   use vtkhdf_ug_file_type
+  use vtkhdf_vtk_cell_types
   use mpi
   implicit none
 


### PR DESCRIPTION
🎯 **What:** This PR deduplicates VTK cell type constants by moving them to a dedicated module `vtkhdf_vtk_cell_types`. It also provides a more exhaustive list of constants and fixes formatting.

💡 **Why:** Centralizing these constants improves maintainability. Per the final feedback, the module name was set to `vtkhdf_vtk_cell_types`, visibility was adjusted to be public by default, and all consumers were updated to use the new module directly.

✅ **Verification:** 
- Manual code review of all refactored files.
- Verified module name, visibility settings, and formatting.
- Confirmed all usages in tests and examples are updated to `use vtkhdf_vtk_cell_types`.
- Build system update was verified.

✨ **Result:** A cleaner, more maintainable codebase with a centralized and expanded set of VTK cell type definitions, following the requested architecture and naming.

---
*PR created automatically by Jules for task [1521675609400667097](https://jules.google.com/task/1521675609400667097) started by @nncarlson*