### PR TITLE
⚡ Optimize block pointer lookup in MultiBlock files

### DIFF
--- a/src/vtkhdf_mb_file_type.F90.fypp
+++ b/src/vtkhdf_mb_file_type.F90.fypp
@@ -50,6 +50,7 @@ module vtkhdf_mb_file_type
     integer(hid_t) :: file_id=H5I_INVALID_HID, vtk_id=H5I_INVALID_HID, ass_id=H5I_INVALID_HID
     integer :: next_bid = 0
     type(pdc_block), pointer :: blocks => null()
+    type(pdc_block), pointer :: last_block => null()
     logical :: is_temporal = .false., write_time_step_called = .false.
   contains
     procedure :: create
@@ -108,6 +109,7 @@ contains
     this%vtk_id  = H5I_INVALID_HID
     this%file_id = H5I_INVALID_HID
     this%next_bid = 0
+    this%last_block => null()
   end subroutine
 
   recursive subroutine pdc_block_delete(this)
@@ -326,7 +328,7 @@ contains
 #:for d in data_specs
 
   subroutine write_${loc}$_data_${s["kind"]}$_${d["suffix"]}$(this, block_name, name, array)
-    class(vtkhdf_mb_file), intent(in) :: this
+    class(vtkhdf_mb_file), intent(inout) :: this
     character(*), intent(in) :: block_name, name
     ${s["decl"]}$, intent(in) :: array${d["array"]}$
     type(vtkhdf_ug), pointer :: bptr
@@ -393,7 +395,7 @@ contains
 #:for d in data_specs
 
   subroutine write_temporal_${loc}$_data_${s["kind"]}$_${d["suffix"]}$(this, block_name, name, array)
-    class(vtkhdf_mb_file), intent(in) :: this
+    class(vtkhdf_mb_file), intent(inout) :: this
     character(*), intent(in) :: block_name, name
     ${s["decl"]}$, intent(in) :: array${d["array"]}$
     type(vtkhdf_ug), pointer :: bptr
@@ -410,11 +412,18 @@ contains
   !! This private procedure returns a pointer to the named block.
   subroutine get_block_ptr(this, name, bptr)
 
-    class(vtkhdf_mb_file), intent(in) :: this
+    class(vtkhdf_mb_file), intent(inout) :: this
     character(*), intent(in) :: name
     type(vtkhdf_ug), pointer, intent(out) :: bptr
 
     type(pdc_block), pointer :: b
+
+    if (associated(this%last_block)) then
+      if (this%last_block%name == name) then
+        bptr => this%last_block%b
+        return
+      end if
+    end if
 
     b => this%blocks
     do while (associated(b))
@@ -423,6 +432,7 @@ contains
     end do
 
     INSIST(this%ctx%global_all(associated(b)))
+    this%last_block => b
     bptr => b%b
 
   end subroutine get_block_ptr


### PR DESCRIPTION
### 💡 What:
Implemented a last-accessed block pointer cache in `vtkhdf_mb_file` to optimize `get_block_ptr`.

### 🎯 Why:
The current implementation uses a linear search ($O(N)$) for every block lookup. Since typical usage involves writing multiple datasets for the same block consecutively, this results in redundant list traversals.

### 📊 Measured Improvement:
While actual benchmarks could not be run due to environment limitations (missing `fypp` and `gfortran`), the theoretical improvement is significant:
- Reduces lookup complexity from $O(M \times N)$ to $O(N)$ for $M$ datasets per block.
- For a typical case with 10 datasets per block, it skips 90% of the linear search iterations.
- Also skips unnecessary MPI collectives on cache hits, assuming SPMD consistency.

### ⚠️ Note:
This change updates the `intent` of `this` from `in` to `inout` for `write_cell_data`, `write_point_data`, and their temporal counterparts. This is necessary to update the internal cache state. All callers within the provided repository (tests and examples) remain compatible.

---
*PR created automatically by Jules for task [10512136781904392267](https://jules.google.com/task/10512136781904392267) started by @nncarlson*