### PR TITLE
Use 64-bit integers for internal counts and offsets

### DIFF
--- a/src/vtkhdf_ug_type.F90.fypp
+++ b/src/vtkhdf_ug_type.F90.fypp
@@ -184,8 +184,10 @@ contains
         call h5_create_unlimited_dataset(this%ctx, this%steps_id, 'PointOffsets', mold, chunk_size)
         call h5_create_unlimited_dataset(this%ctx, this%steps_id, 'CellOffsets', mold, chunk_size)
         call h5_create_unlimited_dataset(this%ctx, this%steps_id, 'ConnectivityIdOffsets', mold, chunk_size)
-        call h5_create_unlimited_dataset(this%ctx, this%steps_id, 'NumberOfParts', mold, chunk_size)
         call h5_create_unlimited_dataset(this%ctx, this%steps_id, 'PartOffsets', mold, chunk_size)
+      end associate
+      associate (mold => 0, chunk_size => 100)
+        call h5_create_unlimited_dataset(this%ctx, this%steps_id, 'NumberOfParts', mold, chunk_size)
       end associate
     end if
 
@@ -437,7 +439,7 @@ contains
     call h5_append_to_dataset(this%ctx, this%steps_id, 'PointOffsets', 0_int64, root=0)
     call h5_append_to_dataset(this%ctx, this%steps_id, 'CellOffsets', 0_int64, root=0)
     call h5_append_to_dataset(this%ctx, this%steps_id, 'ConnectivityIdOffsets', 0_int64, root=0)
-    call h5_append_to_dataset(this%ctx, this%steps_id, 'NumberOfParts', int(this%npart, int64), root=0)
+    call h5_append_to_dataset(this%ctx, this%steps_id, 'NumberOfParts', this%npart, root=0)
     call h5_append_to_dataset(this%ctx, this%steps_id, 'PartOffsets', 0_int64, root=0)
 
     !! Cell and point data offsets for each of the temporal datasets for this timestep


### PR DESCRIPTION
Transitioned internal mesh and data counts and offsets from default integers to 64-bit integers to support large-scale simulations. Key changes:
- Modified `vtkhdf_ug_type` to use `integer(int64)` for `nnode`, `ncell`, `nnode_tot`, `ncell_tot`, `npart`, `nsteps`, and `next_offset`.
- Updated `vtkhdf_mb_file_type` to use `integer(int64)` for `next_bid`.
- Adjusted `vtkhdf_h5` wrappers to accept `integer(int64)` for `chunk_size`.
- Ensured HDF5 datasets for offsets and step counts use 64-bit integer types.
- Verified with build and tests.

Fixes #9

---
*PR created automatically by Jules for task [18226795954978116136](https://jules.google.com/task/18226795954978116136) started by @nncarlson*