### PR TITLE
Cache CI environment in GHCR container

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,45 @@
+name: Build and Push CI Container
+
+on:
+  push:
+    paths:
+      - '.github/workflows/docker/Dockerfile'
+      - '.github/workflows/build-container.yml'
+    branches:
+      - master
+  pull_request:
+    paths:
+      - '.github/workflows/docker/Dockerfile'
+      - '.github/workflows/build-container.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .github/workflows/docker
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/${{ lower(github.repository) }}/fvtkhdf-ci:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   build-test:
     name: Build & Test (Ubuntu/GFortran)
     runs-on: ubuntu-latest
+    container: ghcr.io/${{ lower(github.repository) }}/fvtkhdf-ci:latest
     
     strategy:
       fail-fast: false
@@ -15,20 +16,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gfortran cmake python3-pip
-        # Install HDF5 (Serial or MPI version based on matrix)
-        if [ "${{ matrix.mpi }}" == "ON" ]; then
-          sudo apt-get install -y libopenmpi-dev libhdf5-openmpi-dev
-        else
-          sudo apt-get install -y libhdf5-dev
-        fi
-
-    - name: Install fypp
-      run: pip3 install fypp
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/docker/Dockerfile
+++ b/.github/workflows/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:24.04
+
+# Avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    gfortran \
+    cmake \
+    python3-pip \
+    libhdf5-dev \
+    libopenmpi-dev \
+    libhdf5-openmpi-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install python packages globally
+# Ubuntu 24.04 requires --break-system-packages for global pip install
+RUN pip3 install --break-system-packages fypp sphinx furo
+
+# Set environment variables for MPI
+ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
+CMD ["/bin/bash"]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,15 +17,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: ghcr.io/${{ lower(github.repository) }}/fvtkhdf-ci:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gfortran cmake python3-pip libhdf5-dev
-          pip3 install fypp sphinx furo
 
       - name: Configure CMake
         run: |


### PR DESCRIPTION
This change moves the CI environment from a manually configured one in each job to a pre-built Docker container hosted on GitHub Container Registry (GHCR). This significantly reduces CI startup time by caching all system and Python dependencies (gfortran, HDF5, MPI, fypp, Sphinx, etc.). The container is automatically rebuilt and pushed when the Dockerfile changes.

Fixes #19

---
*PR created automatically by Jules for task [13170312224193001078](https://jules.google.com/task/13170312224193001078) started by @nncarlson*